### PR TITLE
Fix file import logic by introducing persistent identifiers

### DIFF
--- a/pulakat/code-NDI/+ndi/+nansen/+fun/getIdentifier.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+fun/getIdentifier.m
@@ -1,0 +1,74 @@
+function identifier = getIdentifier(dataTable, type, labName)
+%GETIDENTIFIER Generates unique identifiers for subjects and files.
+%
+%   IDENTIFIER = GETIDENTIFIER(DATATABLE, TYPE) creates a cell array of
+%   unique identifiers for each row in the DATATABLE of the specified TYPE
+%   ('Subject' or 'File').
+%
+%   Inputs:
+%       dataTable (table): The metadata table.
+%       type (char): 'Subject' or 'File'.
+%       labName (char): Optional lab name for retrieving project settings.
+%
+%   Outputs:
+%       identifier (cellstr): Unique identifiers for each row.
+
+    arguments
+        dataTable table
+        type {mustBeMember(type, {'Subject', 'File'})}
+        labName {mustBeText} = nansen.getCurrentProject().Name
+    end
+
+    labName = char(labName);
+
+    % Get project info
+    projectFile = fullfile('+ndi','+setup','+conv',['+',labName],'project_info.json');
+    if exist(projectFile, 'file')
+        projectInfo = jsondecode(fileread(projectFile));
+        subjectIdentifiers = projectInfo.subjectIdentifierFields;
+    else
+        % Fallback if project info is not found (should not happen in standard setup)
+        subjectIdentifiers = {'SubjectEnumeratedIdentifier', 'SubjectCageIdentifier', 'SubjectTextIdentifier'};
+    end
+
+    if strcmp(type, 'Subject')
+        keys = [{'SessionName'}, subjectIdentifiers(:)'];
+    elseif strcmp(type, 'File')
+        keys = [{'SessionName', 'ElectronicFileName'}, subjectIdentifiers(:)'];
+    end
+
+    % Ensure all keys exist in dataTable
+    for i = 1:numel(keys)
+        if ~ismember(keys{i}, dataTable.Properties.VariableNames)
+             dataTable.(keys{i}) = repmat({''}, height(dataTable), 1);
+        end
+    end
+
+    % Generate identifier
+    identifier = cell(height(dataTable), 1);
+    for i = 1:height(dataTable)
+        parts = cell(numel(keys), 1);
+        for j = 1:numel(keys)
+            val = dataTable.(keys{j}){i};
+
+            % Handle different data types
+            if isnumeric(val)
+                val = num2str(val);
+            elseif isdatetime(val)
+                val = datestr(val, 'yyyymmdd');
+            end
+
+            if iscell(val); val = val{1}; end % Handle nested cells
+            if isempty(val); val = 'unknown'; end
+
+            % If it's a file path, just use the name
+            if strcmp(keys{j}, 'ElectronicFileName')
+                [~, fName, fExt] = fileparts(char(val));
+                val = [fName, fExt];
+            end
+
+            parts{j} = char(val);
+        end
+        identifier{i} = strjoin(parts, '_');
+    end
+end

--- a/pulakat/code-NDI/+ndi/+nansen/+import/+file/auto.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+import/+file/auto.m
@@ -78,6 +78,7 @@ dataTable_new.SessionIdentifier = repmat({session.id}, height(dataTable_new), 1)
 dataTable_new.SessionName = repmat({session.reference}, height(dataTable_new), 1);
 dataTable_new.SessionPath = repmat({session.path}, height(dataTable_new), 1);
 dataTable_new.FileDocumentIdentifier = repmat({''}, height(dataTable_new), 1);
+dataTable_new.FileIdentifier = ndi.nansen.fun.getIdentifier(dataTable_new, 'File', labName);
 dataTable_new.DateAdded = repmat(datetime('now'), height(dataTable_new), 1);
 dataTable_new.Cloud = false(height(dataTable_new), 1);
 

--- a/pulakat/code-NDI/+ndi/+nansen/+import/+file/manual.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+import/+file/manual.m
@@ -121,6 +121,7 @@ dataTable_new.SessionIdentifier = repmat({session.id}, height(dataTable_new), 1)
 dataTable_new.SessionName = repmat({session.reference}, height(dataTable_new), 1);
 dataTable_new.SessionPath = repmat({session.path}, height(dataTable_new), 1);
 dataTable_new.FileDocumentIdentifier = repmat({''}, height(dataTable_new), 1);
+dataTable_new.FileIdentifier = ndi.nansen.fun.getIdentifier(dataTable_new, 'File', labName);
 dataTable_new.DateAdded = repmat(datetime('now'), height(dataTable_new), 1);
 dataTable_new.Cloud = false(height(dataTable_new), 1);
 

--- a/pulakat/code-NDI/+ndi/+nansen/+import/+subject/auto.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+import/+subject/auto.m
@@ -94,6 +94,7 @@ subjectTable_new{:,'SessionIdentifier'} = session.id;
 subjectTable_new{:,'SessionName'} = session.reference;
 subjectTable_new{:,'SessionPath'} = session.path;
 subjectTable_new{:,'SubjectDocumentIdentifier'} = repmat({''}, height(subjectTable_new), 1);
+subjectTable_new{:,'SubjectIdentifier'} = ndi.nansen.fun.getIdentifier(subjectTable_new, 'Subject', labName);
 subjectTable_new{:,'DateAdded'} = repmat(datetime('now'), height(subjectTable_new), 1);
 subjectTable_new{:,'Cloud'} = false(height(subjectTable_new), 1);
 

--- a/pulakat/code-NDI/+ndi/+nansen/+metatable/add.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+metatable/add.m
@@ -34,7 +34,7 @@ metaTableEntry = metaTableCatalog.getEntry(dataName);
 if isempty(metaTableCatalog.Table) | options.Overwrite | isempty(metaTableEntry) || ...
         ~exist(fullfile(metaTableEntry.SavePath,metaTableEntry.FileName),'file')
     % Add new meta table to project
-    if strcmp(dataName,'File')
+    if ismember(dataName, {'File', 'Subject'})
         metaTable = nansen.metadata.MetaTable(dataTable, ...
             'MetaTableClass', dataName, ...
             'ItemClassName', 'table2struct', ...
@@ -49,6 +49,14 @@ if isempty(metaTableCatalog.Table) | options.Overwrite | isempty(metaTableEntry)
 else
     % Update meta table
     metaTable = project.MetaTableCatalog.getMetaTable(dataName);
+
+    % Ensure Subject/File identifiers are present
+    if ismember(dataName, {'Subject', 'File'})
+        idVar = [dataName, 'Identifier'];
+        if ~ismember(idVar, dataTable.Properties.VariableNames)
+             dataTable.(idVar) = ndi.nansen.fun.getIdentifier(dataTable, dataName);
+        end
+    end
 
     % Align columns between existing metatable and new dataTable
     % (Workaround for Nansen bug where table concatenation fails if columns don't match)
@@ -77,9 +85,9 @@ else
 
             % Use identifying fields to find unique rows
             if strcmp(dataName, 'Subject')
-                keys = {'SessionName', 'SubjectEnumeratedIdentifier', 'SubjectCageIdentifier', 'SubjectTextIdentifier'};
+                keys = {'SubjectIdentifier'};
             elseif strcmp(dataName, 'File')
-                keys = {'SessionName', 'ElectronicFileName', 'DataTypeName', 'SubjectEnumeratedIdentifier', 'SubjectCageIdentifier', 'SubjectTextIdentifier'};
+                keys = {'FileIdentifier'};
             elseif strcmp(dataName, 'Session')
                 keys = {'SessionName', 'SessionPath'};
             else
@@ -98,9 +106,9 @@ else
 
     % Use identifying fields to find unique rows
     if strcmp(dataName, 'Subject')
-        keys = {'SessionName', 'SubjectEnumeratedIdentifier', 'SubjectCageIdentifier', 'SubjectTextIdentifier'};
+        keys = {'SubjectIdentifier'};
     elseif strcmp(dataName, 'File')
-        keys = {'SessionName', 'ElectronicFileName', 'DataTypeName', 'SubjectEnumeratedIdentifier', 'SubjectCageIdentifier', 'SubjectTextIdentifier'};
+        keys = {'FileIdentifier'};
     elseif strcmp(dataName, 'Session')
         keys = {'SessionName', 'SessionPath'};
     else

--- a/pulakat/code-NDI/+ndi/+nansen/+metatable/file.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+metatable/file.m
@@ -97,9 +97,7 @@ if ~isempty(dataTable)
         'SessionPath','DatasetDocumentIdentifier','DatasetIdentifier'});
     dataTable = ndi.fun.table.join({dataTable, ...
         subjectTable(:,subjectVariables)});
-    dataTable.FileIdentifier = cellfun(@(f,s) [f,'_',s],...
-        dataTable.FileDocumentIdentifier,dataTable.SubjectDocumentIdentifier,...
-        'UniformOutput',false);
+    dataTable.FileIdentifier = ndi.nansen.fun.getIdentifier(dataTable, 'File');
 
     if isa(dataset,'ndi.dataset.dir')
         statusTable = ndi.nansen.sync.status(dataset);

--- a/pulakat/code-NDI/+ndi/+nansen/+metatable/subject.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+metatable/subject.m
@@ -59,6 +59,9 @@ end
 % Add session info to subject table
 subjectTable = innerjoin(subjectTable,removevars(sessionTable,{'DateAdded', 'NumSubjects', 'NumFiles'}));
 
+% Add SubjectIdentifier
+subjectTable.SubjectIdentifier = ndi.nansen.fun.getIdentifier(subjectTable, 'Subject');
+
 % Add NumFiles column for each subject
 try
     project = nansen.getCurrentProject();

--- a/pulakat/code/+pulakat/+sessionmethod/+methods/+import/+files/auto.m
+++ b/pulakat/code/+pulakat/+sessionmethod/+methods/+import/+files/auto.m
@@ -37,13 +37,14 @@ function varargout = auto(sessionObject, varargin)
     % Add files to session
     dataTable = ndi.nansen.import.file.auto(session);
 
-    % Add cloud status to subject table
+    % Add cloud status to data table
     dataset = ndi.nansen.fun.datasetID2Object(sessionObject.DatasetIdentifier);
     statusTable = ndi.nansen.sync.status(dataset);
-    dataTable = join(dataTable,statusTable,'LeftKeys',...
-        'FileDocumentIdentifier','RightKeys','DocumentIdentifier');
+    [Lia, Locb] = ismember(dataTable.FileDocumentIdentifier, statusTable.DocumentIdentifier);
+    dataTable.Cloud = false(height(dataTable), 1);
+    dataTable.Cloud(Lia) = statusTable.Cloud(Locb(Lia));
 
-    % Add subjects to metatable
+    % Add files to metatable
     ndi.nansen.metatable.add(dataTable,'File');
 
     % Return session object (please do not remove):

--- a/pulakat/code/+pulakat/+sessionmethod/+methods/+import/+subjects/auto.m
+++ b/pulakat/code/+pulakat/+sessionmethod/+methods/+import/+subjects/auto.m
@@ -35,14 +35,14 @@ function varargout = auto(sessionObject, varargin)
     session = ndi.session.dir(sessionObject.SessionPath);
 
     % Add subjects to session
-    ndi.nansen.import.subject.auto(session);
-    subjectTable = ndi.nansen.metatable.subject(session);
+    subjectTable = ndi.nansen.import.subject.auto(session);
 
     % Add cloud status to subject table
     dataset = ndi.nansen.fun.datasetID2Object(sessionObject.DatasetIdentifier);
     statusTable = ndi.nansen.sync.status(dataset);
-    subjectTable = join(subjectTable,statusTable,'LeftKeys',...
-        'SubjectDocumentIdentifier','RightKeys','DocumentIdentifier');
+    [Lia, Locb] = ismember(subjectTable.SubjectDocumentIdentifier, statusTable.DocumentIdentifier);
+    subjectTable.Cloud = false(height(subjectTable), 1);
+    subjectTable.Cloud(Lia) = statusTable.Cloud(Locb(Lia));
 
     % Add subjects to metatable
     ndi.nansen.metatable.add(subjectTable,'Subject');

--- a/pulakat/metadata/tables/metatable_column_settings.json
+++ b/pulakat/metadata/tables/metatable_column_settings.json
@@ -99,6 +99,15 @@
     "ColumnOrder": 10
   },
   {
+    "VariableName": "SubjectIdentifier",
+    "ColumnLabel": "Subject Identifier",
+    "ShowColumn": false,
+    "SkipColumn": false,
+    "ColumnWidth": 100,
+    "IsEditable": false,
+    "ColumnOrder": 10
+  },
+  {
     "VariableName": "SubjectLocalIdentifier",
     "ColumnLabel": "Subject Local Identifier",
     "ShowColumn": true,


### PR DESCRIPTION
The task was to fix a logic issue when adding files to subjects that don't have NDI documents yet.

I implemented the following:
1.  **New Identifier Helper**: Created `ndi.nansen.fun.getIdentifier` to generate unique, persistent identifiers for subjects and files based on session name and identifying metadata.
2.  **Populate Identifiers**: Updated `ndi.nansen.import.subject.auto`, `ndi.nansen.import.file.auto`, and `ndi.nansen.import.file.manual` to generate these identifiers upon import.
3.  **Metatable Integration**: Updated `ndi.nansen.metatable.add` to use `SubjectIdentifier` as the primary key for subjects (matching how `FileIdentifier` was already used for files). Updated matching logic to use these identifiers instead of multiple separate fields.
4.  **Session Method Fixes**: In `pulakat/code/+pulakat/+sessionmethod/+methods/+import/+files/auto.m` and `pulakat/code/+pulakat/+sessionmethod/+methods/+import/+subjects/auto.m`, replaced problematic `join` operations with `ismember` logic. This prevents rows for new subjects/files (which have empty `DocumentIdentifiers`) from being dropped during the cloud status merge.
5.  **Configuration**: Added `SubjectIdentifier` to `metatable_column_settings.json`.

These changes ensure that subjects and files can be reliably tracked and matched in the metatables even before they are synchronized with the NDI database.

---
*PR created automatically by Jules for task [6247284955619609929](https://jules.google.com/task/6247284955619609929) started by @jesshaley*