### PR TITLE
Update dataset.m

### DIFF
--- a/pulakat/code-NDI/+ndi/+nansen/+metatable/dataset.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+metatable/dataset.m
@@ -9,6 +9,9 @@ end
 
 % Get dataset metadata
 cloudDatasetID = ndi.cloud.internal.getCloudDatasetIdForLocalDataset(dataset);
+if isempty(cloudDatasetID)
+    error('Could not find a matching cloud dataset for the local dataset')
+end
 [success,datasetInfo] = ndi.cloud.api.datasets.getDataset(cloudDatasetID);
 if ~success
     warning('Error encountered retrieving dataset information from cloud. Try logging in again.')


### PR DESCRIPTION
Add error if no matching cloud datasets are found.

If I run pulakat.startup, I get the following error:

```Matlab
Error using ndi.cloud.api.implementation.datasets.GetDataset/execute (line 38)
"datasetId" is a required parameter for the "get_dataset" endpoint

Error in ndi.cloud.api.datasets.getDataset (line 28)
    [b, answer, apiResponse, apiURL] = api_call.execute();
                                       ^^^^^^^^^^^^^^^^^^
Error in ndi.nansen.metatable.dataset (line 12)
[success,datasetInfo] = ndi.cloud.api.datasets.getDataset(cloudDatasetID);
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in ndi.nansen.startup (line 61)
datasetTable = ndi.nansen.metatable.dataset(dataset);
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in pulakat.startup (line 10)
ndi.nansen.startup('pulakat');
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This happens because this call:
https://github.com/Waltham-Data-Science/nansen-pulakat/blob/164005da93b64a383c909f8be2c2ebe6fda4faf4/pulakat/code-NDI/%2Bndi/%2Bnansen/%2Bmetatable/dataset.m#L11

returns an empty string. 

Is it expected that this should always find a matching cloud dataset?