### PR TITLE
Create data directory and pass path to ndi.nansen.startup

### DIFF
--- a/install.m
+++ b/install.m
@@ -86,7 +86,11 @@ end
 
 % 10. Initialize 'pulakat' project and launch
 if ~isempty(which('ndi.nansen.startup'))
-    ndi.nansen.startup('pulakat');
+    dataPath = fullfile(userpath,'ndi','data');
+    if ~isfolder(dataPath)
+        mkdir(dataPath);
+    end
+    ndi.nansen.startup('pulakat', dataPath);
 else
     warning('ndi.nansen.startup not found. Please ensure all repositories are on the MATLAB path.');
 end


### PR DESCRIPTION
## Summary
Updated the installation script to ensure the NDI data directory exists before initializing the 'pulakat' project, and now passes the data path as a parameter to `ndi.nansen.startup()`.

## Key Changes
- Added logic to construct the data directory path under the user's MATLAB path (`userpath/ndi/data`)
- Added directory creation check that creates the data folder if it doesn't already exist
- Modified the `ndi.nansen.startup()` call to pass the data path as a second argument

## Implementation Details
The changes ensure that the required data directory structure is properly initialized during installation before the startup function is called, preventing potential errors from missing directories. The data path is now explicitly provided to the startup function rather than relying on implicit path resolution.

https://claude.ai/code/session_01FgytwH58oEfjKVjHxCUcti