### PR TITLE
Populate SubjectIdentifier in File metatable by joining Subject table

### DIFF
--- a/pulakat/code-NDI/+ndi/+nansen/+metatable/+update/file.m
+++ b/pulakat/code-NDI/+ndi/+nansen/+metatable/+update/file.m
@@ -127,4 +127,32 @@ end
 % Stack tables
 fileTable = ndi.fun.table.vstack(fileTables);
 
+% Populate SubjectIdentifier by joining against the Subject metatable.
+% The File tablevariable update functions use obj.SubjectIdentifier to
+% look up subject-derived fields (SubjectLocalIdentifier, SessionName,
+% etc.). update/file.m only captures SubjectDocumentIdentifier from NDI
+% dependencies, so SubjectIdentifier must be resolved via the already-
+% merged Subject metatable (see updateAll for the enforced order).
+if ~isempty(fileTable)
+    project = nansen.getCurrentProject();
+    metaTableCatalog = project.MetaTableCatalog;
+    if ~isempty(metaTableCatalog.Table) && ...
+            ismember('Subject',metaTableCatalog.Table.MetaTableName)
+        subjectEntries = metaTableCatalog.getMetaTable('Subject').entries;
+        if ~isempty(subjectEntries) && ...
+                all(ismember({'SubjectDocumentIdentifier','SubjectIdentifier'}, ...
+                    subjectEntries.Properties.VariableNames))
+            fileTable.SubjectIdentifier = repmat({'N/A'},height(fileTable),1);
+            for i = 1:height(fileTable)
+                ind = find(strcmp(subjectEntries.SubjectDocumentIdentifier, ...
+                    fileTable.SubjectDocumentIdentifier{i}),1);
+                if ~isempty(ind)
+                    fileTable.SubjectIdentifier{i} = ...
+                        subjectEntries.SubjectIdentifier{ind};
+                end
+            end
+        end
+    end
+end
+
 end


### PR DESCRIPTION
## Summary
Added logic to populate the `SubjectIdentifier` field in the File metatable by performing a join operation against the already-merged Subject metatable. This resolves subject identifiers that cannot be directly captured from NDI dependencies.

## Key Changes
- Added post-processing step after File table stacking to join against Subject metatable entries
- Populates `SubjectIdentifier` by matching `SubjectDocumentIdentifier` values between File and Subject tables
- Initializes unmatched entries with 'N/A' as a default value
- Includes validation checks to ensure Subject metatable exists and contains required columns before attempting the join

## Implementation Details
- The join operation iterates through each File table row and looks up the corresponding Subject entry by `SubjectDocumentIdentifier`
- Relies on the Subject metatable being already merged (enforced by `updateAll` execution order)
- Gracefully handles cases where the Subject metatable is unavailable or incomplete
- Uses a simple linear search approach with early termination on first match

https://claude.ai/code/session_01WLoX2ZyFJGSZm7TYoULnrM