### PR TITLE
Save metatable after variable-update loop so values reach disk

### DIFF
--- a/src/ndi/+ndi/+nansen/+metatable/update.m
+++ b/src/ndi/+ndi/+nansen/+metatable/update.m
@@ -119,6 +119,22 @@ if ~isequal(options.UpdateVariableNames,{''})
     for i = 1:numel(updateVariableNames)
         metaTable.updateTableVariable(updateVariableNames{i}, rowIndices);
     end
+
+    % Persist the computed values. metaTable.updateTableVariable
+    % mutates obj.entries in memory but does not save — without this,
+    % values for every HasUpdateFunction variable (Treatment,
+    % NumFiles, NumSubjects, DataTypeName, ...) live only in the
+    % local in-memory copy of the metatable that goes out of scope
+    % when this function returns. The next consumer (the GUI on
+    % launch, or another call to catalog.getMetaTable) reads from
+    % disk and sees the DEFAULT_VALUE that addMissingVarsToMetaTable
+    % wrote when it added the column. Force-save because
+    % editEntries is called with subscripted-cell-assignment paths
+    % that don't always trigger MetaTable's set.entries setter, so
+    % IsClean can stay true even after real mutations.
+    if ~isempty(updateVariableNames) && ~isempty(metaTable.filepath)
+        metaTable.save(true);
+    end
 end
 
 end


### PR DESCRIPTION
When merge.m started passing AutoUpdateValues=false to addMissingVarsToMetaTable (commit f94e520, "Defer per-column update() to updateAll's tail pass"), it cleanly split the work: addMissingVarsToMetaTable now just adds columns at DEFAULT_VALUE and saves, and updateAll's tail pass via update.m runs the per- column update() calls.

The split lost the save. metaTable.updateTableVariable mutates obj.entries in memory but doesn't call obj.save() itself, and update.m's tail loop never did either. The previously-saved disk copy retained the DEFAULT_VALUE that addMissingVarsToMetaTable wrote when it created the column. On every subsequent catalog.getMetaTable load — including the one nansen.App does at GUI launch — disk state was the source of truth, so the GUI saw defaults for Treatment, NumFiles, NumSubjects, DataTypeName, BiologicalSexName, SpeciesName, StrainName.

Fix: force-save the metatable after the variable-update loop, guarded by ~isempty(metaTable.filepath) so test fixtures that build a MetaTable in memory before archive() runs are unaffected. The force flag is necessary because editEntries paths use subscripted cell-assignment that doesn't always trigger MetaTable's set.entries setter, so IsClean can stay true even after real mutations and a non-forced save would be a no-op.

This restores the disk write that AutoUpdateValues=true did inside addMissingVarsToMetaTable, but at the right point in the pipeline: once per update.m call, after every variable-update finished, so the row-targeted optimisations from commit ae1df4b still pay off.