### PR TITLE
Replace removed addMissingVarsToMetaTable in merge.m

### DIFF
--- a/src/ndi/+ndi/+nansen/+metatable/merge.m
+++ b/src/ndi/+ndi/+nansen/+metatable/merge.m
@@ -70,7 +70,7 @@ if isempty(dataTable)
             % below; updateAll's second pass refreshes every
             % HasUpdateFunction variable uniformly.
             oldVars = metaTable.entries.Properties.VariableNames;
-            metaTable.addMissingVarsToMetaTable(dataName, ...
+            project.synchronizeMetaTableVariables(metaTable, ...
                 'AutoUpdateValues', false);
             if ~isequal(metaTable.entries.Properties.VariableNames, oldVars)
                 changed = true;
@@ -92,14 +92,14 @@ if ~isempty(metaTableCatalog.Table) && ...
         % tablevariable added after the local metatable was first
         % saved (e.g. Treatment, NumFiles, DataTypeName) never gets
         % a column in the user's metatable and never appears in the
-        % GUI. addMissingVarsToMetaTable adds the column with its
-        % DEFAULT_VALUE; pass AutoUpdateValues=false so the per-
-        % column update() pass is skipped here. updateAll's second
-        % pass (UpdateTable=false) refreshes every HasUpdateFunction
-        % variable uniformly, so doing it here too would just be
-        % redundant work for newly-added columns.
+        % GUI. synchronizeMetaTableVariables adds the column with
+        % its DEFAULT_VALUE; pass AutoUpdateValues=false so the
+        % per-column update() pass is skipped here. updateAll's
+        % second pass (UpdateTable=false) refreshes every
+        % HasUpdateFunction variable uniformly, so doing it here
+        % too would just be redundant work for newly-added columns.
         oldVars = metaTable.entries.Properties.VariableNames;
-        metaTable.addMissingVarsToMetaTable(dataName, ...
+        project.synchronizeMetaTableVariables(metaTable, ...
             'AutoUpdateValues', false);
         if ~isequal(metaTable.entries.Properties.VariableNames, oldVars)
             changed = true;
@@ -121,7 +121,7 @@ if ~exist('metaTable','var')
     % AutoUpdateValues=false matches the existing-metatable branches
     % above; updateAll's tail pass refreshes every HasUpdateFunction
     % variable uniformly so we don't run update() per-column twice.
-    metaTable.addMissingVarsToMetaTable(dataName, ...
+    project.synchronizeMetaTableVariables(metaTable, ...
         'AutoUpdateValues', false);
     changed = true;  % brand-new metatable always counts as a change
     return


### PR DESCRIPTION
## Why offline tests are red on PR #39

PR #39 adapts to NANSEN's `MetaTable` refactor (VervaekeLab/NANSEN#78) and fixes the `class()` override and `entry.SavePath`/`entry.FileName` removals. But that upstream PR also removed a third method: `MetaTable.addMissingVarsToMetaTable`. The replacement is `Project.synchronizeMetaTableVariables(metaTable, ...)` (which internally derives the table type via `metaTable.getTableType()`).

`src/ndi/+ndi/+nansen/+metatable/merge.m` calls `addMissingVarsToMetaTable` at three sites (lines 73, 102, 124). Against NANSEN `dev` those calls hit an undefined method, so every `MetatableMerge` test that exercises an existing-or-new metatable path fails — which is why `Offline tests (MATLAB latest)` is red on #39.

## Change

Swap each `metaTable.addMissingVarsToMetaTable(dataName, ...)` for `project.synchronizeMetaTableVariables(metaTable, ...)`. Same `AutoUpdateValues=false` semantics; `dataName` is no longer needed because the project method reads `metaTable.getTableType()`.

Comment in `+fun/listUniqueMetaTableValues.m` and `+fun/countUniqueMetaTableValues.m` and `+metatable/update.m` still mention the old name — left as-is since they describe behavior, not API, and the new method calls into `addMissingTableVariables` privately.

## Suggested merge plan

Targeting #39's branch directly so it lands as a fixup. Once green, squash-merge #39.

## Test plan

- [ ] CI offline tests pass on PR #39 after this lands on its branch
- [ ] Cloud tests stay green (or skipped on forked-PR runs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUjQGhdCABv8hLENHAJi8x)_