### PR TITLE
Verify cloud binary presence in sync.status; surface export failures (#43)

### DIFF
--- a/src/ndi/+ndi/+nansen/+export/genericFiles.m
+++ b/src/ndi/+ndi/+nansen/+export/genericFiles.m
@@ -51,6 +51,33 @@ if ~isempty(cloudDocumentIDs)
     [success, errorMessage, report] = ndi.cloud.download.downloadGenericFiles(dataset,...
         cloudDocumentIDs,exportFolder,'Verbose',options.Verbose,...
         'Zip',options.Zip,'NamingStrategy',options.NamingStrategy);
+
+    % downloadGenericFiles only sets success=false on catastrophic
+    % failure (an exception in its outer try). Per-file 404s are
+    % caught inside its loop and reported only as warnings, so the
+    % return value lies about partial failures. Compare expected vs
+    % actually-downloaded to surface that ourselves. See
+    % nansen-pulakat issue #43 for the underlying upstream sync bug
+    % that produces these 404s in the first place.
+    numCloud = numel(cloudDocumentIDs);
+    if isfield(report,'downloaded_filenames')
+        numDownloaded = numel(report.downloaded_filenames);
+    else
+        numDownloaded = 0;
+    end
+    if numDownloaded < numCloud
+        success = false;
+        report.failed_count = numCloud - numDownloaded;
+        report.attempted_count = numCloud;
+        if isempty(errorMessage)
+            errorMessage = sprintf( ...
+                ['%d of %d cloud documents had no downloadable binary ' ...
+                 '(the cloud reports the document exists but does not ' ...
+                 'have the file). See nansen-pulakat issue #43 for ' ...
+                 'context on the underlying upstream sync bug.'], ...
+                report.failed_count, numCloud);
+        end
+    end
 end
 
 % "Download" local files

--- a/src/ndi/+ndi/+nansen/+sync/status.m
+++ b/src/ndi/+ndi/+nansen/+sync/status.m
@@ -3,7 +3,21 @@ function [statusTable] = status(dataset, options)
 %
 %   This function compares the local documents in an NDI dataset with its
 %   sync index to determine which documents have been uploaded to the
-%   cloud and which are pending.
+%   cloud and which are pending. For documents that have associated
+%   binary files (e.g. generic_file documents) it also verifies that
+%   every binary is present on the cloud, not just that the metadata
+%   document was last-synced.
+%
+%   The sync index records only document IDs that were uploaded — it
+%   does not track per-binary upload outcomes. Upstream's
+%   ndi.cloud.sync.uploadNew silently discards the success return from
+%   ndi.cloud.sync.internal.uploadFilesForDatasetDocuments and updates
+%   the sync index regardless, so a document can be in the sync index
+%   while its file binary was never registered with the cloud's file
+%   service. Without the binary-presence check, this function would
+%   report Cloud=true for that row and the user would only discover the
+%   missing binary on a subsequent Export → 404. See
+%   https://github.com/Waltham-Data-Science/nansen-pulakat/issues/43.
 %
 %   Inputs:
 %      dataset (ndi.dataset.dir): The NDI dataset object.
@@ -28,6 +42,8 @@ arguments
     options.Verbose (1,1) logical = false
 end
 
+funcId = 'NDI:Nansen:Sync:Status';
+
 % 1. Read sync index
 syncIndex = ndi.cloud.sync.internal.index.readSyncIndex(dataset);
 if isempty(syncIndex) || isempty(syncIndex.remoteDocumentIdsLastSync)
@@ -46,17 +62,161 @@ if options.Verbose
     fprintf('[NDI Sync Status] Found %d documents locally.\n', numel(localDocumentIds));
 end
 
-% 3. Calculate differences: documents added locally since last sync
+% 3. Resolve the cloud's actual uploaded-binary set. Empty if the
+% dataset isn't linked to a cloud dataset, if listFiles fails, or if
+% the API response shape can't be interpreted — in any of those cases
+% we fall back to the previous document-only semantics rather than
+% blocking the table refresh.
+cloudFileUids = resolveCloudFileSet(dataset, funcId, options.Verbose);
+
+% 4. Find documents whose binaries are missing on the cloud. Only check
+% the documents that are both in the sync index AND present locally,
+% since we can't inspect binaries of cloud-only docs from here and
+% local-only docs are already going to be Cloud=false below.
+missingBinaryDocIds = strings(0,1);
+if ~isempty(cloudFileUids)
+    localAlsoOnCloud = intersect(string(localDocumentIds), remoteIdsLastSync, 'stable');
+    missingBinaryDocIds = findDocsWithMissingBinaries(...
+        dataset, localAlsoOnCloud, cloudFileUids, funcId, options.Verbose);
+end
+
+% 5. Calculate differences: documents added locally since last sync
 [ndiIdsToUpload, ~] = setdiff(localDocumentIds, remoteIdsLastSync, 'stable');
 if options.Verbose
     fprintf('[NDI Sync Status] Found %d documents added locally since last sync.\n', ...
         numel(ndiIdsToUpload));
 end
 
-% 4. Create status table
+% 6. Create status table
 DocumentIdentifier = [cellstr(remoteIdsLastSync);cellstr(ndiIdsToUpload)'];
 Cloud = false(size(DocumentIdentifier));
 Cloud(1:numel(remoteIdsLastSync)) = true;
+
+% 7. Downgrade Cloud=true → false for documents whose binaries the
+% cloud is missing. The sync index says they're on cloud; the file
+% service says otherwise; treat them as not-yet-synced so the table
+% reflects what the user will actually be able to download.
+if ~isempty(missingBinaryDocIds)
+    downgradeMask = ismember(string(DocumentIdentifier), missingBinaryDocIds);
+    Cloud(downgradeMask) = false;
+    if options.Verbose
+        fprintf(['[NDI Sync Status] %d documents in sync index but ' ...
+                 'missing their binaries on cloud; downgraded Cloud=false.\n'], ...
+                sum(downgradeMask));
+    end
+end
+
 statusTable = table(DocumentIdentifier,Cloud);
 
+end
+
+function uids = resolveCloudFileSet(dataset, funcId, verbose)
+%resolveCloudFileSet Return the set of file UIDs the cloud reports as uploaded.
+%
+%   Empty result is a sentinel: "couldn't verify, fall back to
+%   document-only semantics". Three reasons to return empty:
+%     1. dataset isn't linked to a cloud dataset (no dataset_remote
+%        document) — nothing to verify against.
+%     2. listFiles API call fails — assume transient and don't lie.
+%     3. listFiles response lacks the 'uploaded' field — can't
+%        distinguish registered-but-pending from registered-and-uploaded.
+    uids = strings(0,1);
+
+    try
+        q = ndi.query('','isa','dataset_remote');
+        remoteDocs = dataset.database_search(q);
+        if isempty(remoteDocs)
+            if verbose
+                fprintf(['[%s] Dataset has no dataset_remote document; ' ...
+                         'binary check skipped.\n'], funcId);
+            end
+            return
+        end
+        cloudDatasetId = remoteDocs{1}.document_properties.dataset_remote.dataset_id;
+    catch ME
+        if verbose
+            fprintf('[%s] Could not resolve cloud dataset id: %s\n', ...
+                funcId, ME.message);
+        end
+        return
+    end
+
+    try
+        [ok, fileList] = ndi.cloud.api.files.listFiles(cloudDatasetId, ...
+            "checkForUpdates", true);
+    catch ME
+        if verbose
+            fprintf(['[%s] listFiles call failed (%s); binary check ' ...
+                     'skipped.\n'], funcId, ME.message);
+        end
+        return
+    end
+
+    if ~ok || isempty(fileList)
+        if verbose
+            fprintf(['[%s] listFiles returned ok=%d count=%d; binary ' ...
+                     'check skipped.\n'], funcId, ok, numel(fileList));
+        end
+        return
+    end
+
+    if ~isfield(fileList(1), 'uploaded')
+        if verbose
+            fprintf(['[%s] Cloud listFiles response lacks the uploaded ' ...
+                     'field; cannot distinguish uploaded from pending. ' ...
+                     'Falling back to document-presence Cloud semantics.\n'], ...
+                    funcId);
+        end
+        return
+    end
+
+    uploadedMask = arrayfun(@(s) isfield(s,'uploaded') && s.uploaded, fileList);
+    uids = string({fileList(uploadedMask).uid});
+end
+
+function missingDocIds = findDocsWithMissingBinaries(dataset, candidateDocIds, ...
+        cloudFileUids, funcId, verbose)
+%findDocsWithMissingBinaries Return doc IDs whose binaries aren't on cloud.
+%
+%   For each candidate document ID, load the document, inspect its
+%   files.file_info entries (skip docs without files — Subject/Session
+%   records, etc. — those keep their sync-index Cloud=true), and check
+%   that every file UID is in the cloudFileUids set. Documents whose
+%   binaries are partially or entirely absent on the cloud are returned
+%   so the caller can downgrade their Cloud column.
+%
+%   Failures inside the loop are logged in verbose mode and skipped —
+%   one malformed document shouldn't prevent reporting on the others.
+    missingDocIds = strings(0,1);
+    if isempty(candidateDocIds); return; end
+
+    if verbose
+        fprintf('[%s] Verifying binaries for %d cloud-and-local documents.\n', ...
+            funcId, numel(candidateDocIds));
+    end
+
+    for i = 1:numel(candidateDocIds)
+        try
+            docs = ndi.session.docinput2docs(dataset, char(candidateDocIds(i)));
+            if isempty(docs); continue; end
+            doc = docs{1};
+            if ~doc.has_files(); continue; end
+
+            fileInfo = doc.document_properties.files.file_info;
+            for j = 1:numel(fileInfo)
+                uid = string(fileInfo(j).uid);
+                if strlength(uid) == 0; continue; end
+                if ~ismember(uid, cloudFileUids)
+                    missingDocIds(end+1) = candidateDocIds(i); %#ok<AGROW>
+                    break
+                end
+            end
+        catch ME
+            if verbose
+                fprintf('[%s] Could not inspect document %s (%s); ' ...
+                        'leaving Cloud unchanged for it.\n', ...
+                        funcId, char(candidateDocIds(i)), ME.message);
+            end
+        end
+    end
 end

--- a/src/pulakat/code/+pulakat/+objectmethod/+file/+methods/export.m
+++ b/src/pulakat/code/+pulakat/+objectmethod/+file/+methods/export.m
@@ -59,9 +59,18 @@ function varargout = export(fileObject, varargin)
     dataset = ndi.nansen.fun.datasetID2Object( ...
         ndi.nansen.fun.resolveDatasetID(datasetID{1}));
 
-    % Download cloud (and local) generic_files
-    ndi.nansen.export.genericFiles(dataset,exportTable,exportFolder,...
-        'NamingStrategy','id');
+    % Download cloud (and local) generic_files. genericFiles returns
+    % success=false when any binary failed to download; surface that
+    % to the user rather than silently reporting Task completed. The
+    % export folder still opens so the user can see the partial result
+    % (metadata.csv plus whatever succeeded).
+    [success, errorMessage] = ndi.nansen.export.genericFiles(dataset, ...
+        exportTable, exportFolder, 'NamingStrategy','id');
+    if ~success
+        warning('Pulakat:ObjectMethod:File:Export:PartialFailure', ...
+            ['[Pulakat:ObjectMethod:File:Export:PartialFailure] ' ...
+             '%s'], errorMessage);
+    end
 
     % Open export folder on computer
     ndi.nansen.fun.openFolder(exportFolder);

--- a/src/pulakat/code/+pulakat/+objectmethod/+subject/+methods/+export/files.m
+++ b/src/pulakat/code/+pulakat/+objectmethod/+subject/+methods/+export/files.m
@@ -48,9 +48,18 @@ function varargout = files(subjectObject, varargin)
     dataset = ndi.nansen.fun.datasetID2Object( ...
         ndi.nansen.fun.resolveDatasetID(datasetID{1}));
 
-    % Download cloud (and local) generic_files
-    ndi.nansen.export.genericFiles(dataset,exportTable,exportFolder,...
-        'NamingStrategy','id');
+    % Download cloud (and local) generic_files. genericFiles returns
+    % success=false when any binary failed to download; surface that
+    % to the user rather than silently reporting Task completed. The
+    % export folder still opens so the user can see the partial result
+    % (metadata.csv plus whatever succeeded).
+    [success, errorMessage] = ndi.nansen.export.genericFiles(dataset, ...
+        exportTable, exportFolder, 'NamingStrategy','id');
+    if ~success
+        warning('Pulakat:ObjectMethod:Subject:Export:Files:PartialFailure', ...
+            ['[Pulakat:ObjectMethod:Subject:Export:Files:PartialFailure] ' ...
+             '%s'], errorMessage);
+    end
 
     % Open export folder on computer
     ndi.nansen.fun.openFolder(exportFolder);

--- a/src/pulakat/code/+pulakat/+sessionmethod/+methods/+export/files.m
+++ b/src/pulakat/code/+pulakat/+sessionmethod/+methods/+export/files.m
@@ -56,9 +56,18 @@ function varargout = files(sessionObject, varargin)
     dataset = ndi.nansen.fun.datasetID2Object( ...
         ndi.nansen.fun.resolveDatasetID(sessionObject.DatasetIdentifier));
 
-    % Download cloud (and local) generic_files
-    ndi.nansen.export.genericFiles(dataset,exportTable,exportFolder,...
-        'NamingStrategy','id');
+    % Download cloud (and local) generic_files. genericFiles returns
+    % success=false when any binary failed to download; surface that
+    % to the user rather than silently reporting Task completed. The
+    % export folder still opens so the user can see the partial result
+    % (metadata.csv plus whatever succeeded).
+    [success, errorMessage] = ndi.nansen.export.genericFiles(dataset, ...
+        exportTable, exportFolder, 'NamingStrategy','id');
+    if ~success
+        warning('Pulakat:SessionMethod:Export:Files:PartialFailure', ...
+            ['[Pulakat:SessionMethod:Export:Files:PartialFailure] ' ...
+             '%s'], errorMessage);
+    end
 
     % Open export folder on computer
     ndi.nansen.fun.openFolder(exportFolder);


### PR DESCRIPTION
Pulakat-side mitigations for [#43](https://github.com/Waltham-Data-Science/nansen-pulakat/issues/43). The underlying upstream NDI-matlab bug (`uploadNew` discards return codes from both `uploadDocumentCollection` and `uploadFilesForDatasetDocuments`, then updates the sync index regardless) needs a fix in `VH-Lab/NDI-matlab`. Pulakat can independently stop trusting the sync index blindly for the Cloud column and stop reporting partial export failures as `Task completed`.

## Summary

Two pulakat-visible bugs fall out of the upstream issue and are fixable here without waiting on upstream:

1. The Cloud column on the Subject / File / Session / Dataset metatables shows `true` for any document whose ID is in the sync index, even when the cloud's file service has no associated binary. Users only discover the missing binary on a subsequent Export → 404.
2. `Subject → Export → Files`, `Session → Export → Files`, and `File → Export` all print `Task completed: files` after running, regardless of whether any binary downloaded. Their inner call to `ndi.nansen.export.genericFiles` already gets `[success, errorMessage]` back but throws the values away.

## What changed

### `ndi.nansen.sync.status` — verify per-binary presence

After computing the existing document-presence diff, also resolve the cloud dataset id from the local `dataset_remote` document, call `ndi.cloud.api.files.listFiles`, and build the set of file UIDs the cloud reports with `uploaded=true`. For documents that are in the sync index AND present locally, load each document and check that every `file_info` UID is in that set. Documents whose binaries are partially or entirely absent on the cloud get `Cloud` downgraded from `true` to `false`.

Three degenerate cases fall back to the previous document-only semantics (with a verbose log line) rather than blocking the table refresh:

- Dataset isn't linked to a cloud dataset (no `dataset_remote` document)
- `listFiles` call fails
- `listFiles` response shape lacks the `uploaded` field

Documents without binaries (Subject / Session records, etc.) keep their sync-index `Cloud=true` because `has_files()` short-circuits them — only `file`-shaped documents go through the binary check.

### `ndi.nansen.export.genericFiles` — detect partial failure

`ndi.cloud.download.downloadGenericFiles` only sets `success=false` on a catastrophic try/catch failure; per-file 404s are caught inside its loop and reported as warnings while the call returns `success=true`. Compare the expected count (`numel(cloudDocumentIDs)`) against `report.downloaded_filenames` length to detect partial failures and downgrade `success` accordingly, adding a `failed_count` to the report and a clear `errorMessage` pointing at #43 for context.

### `pulakat.{objectmethod.subject,sessionmethod,objectmethod.file}.methods.export.files`

All three export methods capture `[success, errorMessage]` from `genericFiles` and `warning(...)` with a `Pulakat:*:PartialFailure` identifier when the export was partial. The export folder still opens so the user can see the `metadata.csv` plus whatever binaries did succeed.

## Out of scope (separate work)

- The upstream root cause is `ndi.cloud.sync.uploadNew` discarding both upload return codes. Issue draft in the [project notes](https://github.com/Waltham-Data-Science/nansen-pulakat/issues/43); to be filed against `VH-Lab/NDI-matlab`.
- `ndi.database.internal.list_binary_files` crashes with "Insufficient number of outputs" when a document's `file_info` lacks a `bytes` field (cloud-only files). Side bug noticed during diagnosis; not exercised by anything this PR touches.

## Test plan

- [ ] Offline CI passes (`ndi.unittest.nansen.ModulePlugins` covers the three export-method classes load and `update()` cleanly; no existing tests for `sync.status` so behavior is verified manually)
- [ ] Manually re-run `Subject → Export → Files` against the dataset that produced #43's 404s; expect the `Pulakat:ObjectMethod:Subject:Export:Files:PartialFailure` warning instead of `Task completed: files`
- [ ] In the same dataset, refresh the File metatable and observe the Cloud column on rows whose binaries are missing — should show `false` instead of the misleading `true` (per #43's diagnostic, those are exactly the rows whose document ID is in the sync index but whose UID isn't in `listFiles`)
- [ ] On a dataset where every document and every binary IS uploaded, confirm the Cloud column still shows `true` (no regression for the happy path)
- [ ] Disconnect / break network and verify `sync.status` still returns a usable table (falls back to document-only semantics rather than throwing)

---
_Tracked alongside [#43](https://github.com/Waltham-Data-Science/nansen-pulakat/issues/43)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7oxviMzuwcExHpW2J1eEs)_