### PR TITLE
Fix hardcoded &quot;subjects&quot; in validation success popup

### DIFF
--- a/src/ndi/+ndi/+nansen/+fun/showValidationReport.m
+++ b/src/ndi/+ndi/+nansen/+fun/showValidationReport.m
@@ -83,7 +83,18 @@ end
 % user doesn't see an empty report window sitting behind the alert.
 allClean = all(isValid) && ~any(isDoc);
 if allClean && ~isInteractive
-    msgbox('All selected subjects are valid.', 'Validation Success');
+    % First word of Title names the entity (e.g. "File validation",
+    % "Subject documents"). Fall back to "items" for callers that pass
+    % a non-entity-prefixed title.
+    titleWords = strsplit(strtrim(options.Title));
+    knownEntities = {'File','Subject','Session','Dataset'};
+    if ~isempty(titleWords) && ismember(titleWords{1}, knownEntities)
+        nounPlural = [lower(titleWords{1}) 's'];
+    else
+        nounPlural = 'items';
+    end
+    msgbox(sprintf('All selected %s are valid.', nounPlural), ...
+        'Validation Success');
     return
 end
 


### PR DESCRIPTION
## Summary

- `showValidationReport`'s all-clean fast path was always announcing "All selected subjects are valid." regardless of which entity was being validated. The helper is shared between Subject and File validators, so calling File > Method > Validate with a fully-valid selection produced a message mentioning subjects.
- Derive the noun from the first word of the `Title` option. Every existing caller already passes a Title that starts with the entity name (`File validation`, `File documents`, `Subject validation`, `Subject documents`).
- Fall back to "items" for any future caller that passes a non-entity-prefixed title.

## Test plan

- [ ] File > Method > Validate against a fully-valid selection: success popup reads "All selected files are valid."
- [ ] Subject > Method > Validate against a fully-valid selection: success popup reads "All selected subjects are valid."
- [ ] Mixed/invalid selection still routes through the interactive uifigure (unchanged code path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01S7oxviMzuwcExHpW2J1eEs)_