### PR TITLE
Install NANSEN&#39;s FEX dependencies in CI

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -165,6 +165,15 @@ jobs:
             addpath(genpath('entity-table/src'));
             addpath(genpath('nansen-pulakat/src'));
             addpath(genpath('nansen-pulakat/tests'));
+            % Re-instantiate the AddonManager against the same folder
+            % the install step populated. The constructor calls
+            % ensureAddonDependenciesOnPath(), which puts the installed
+            % FEX add-ons (recursiveDir, widgets-toolbox, etc.) on the
+            % path in this fresh MATLAB process. Without it, the
+            % previous step's installs are on disk but not visible to
+            % the test step's MATLAB.
+            nansen.config.addons.AddonManager.instance( ...
+                "AddonFolder", fullfile(pwd, 'NANSEN-addons'));
             try; run(fullfile('openMINDS_MATLAB','code','setup.m')); catch ME; ...
                 warning('openMINDS setup failed: %s', ME.message); end
             offlineTests = { ...
@@ -350,6 +359,15 @@ jobs:
             addpath(genpath('entity-table/src'));
             addpath(genpath('nansen-pulakat/src'));
             addpath(genpath('nansen-pulakat/tests'));
+            % Re-instantiate the AddonManager against the same folder
+            % the install step populated. The constructor calls
+            % ensureAddonDependenciesOnPath(), which puts the installed
+            % FEX add-ons (recursiveDir, widgets-toolbox, etc.) on the
+            % path in this fresh MATLAB process. Without it, the
+            % previous step's installs are on disk but not visible to
+            % the test step's MATLAB.
+            nansen.config.addons.AddonManager.instance( ...
+                "AddonFolder", fullfile(pwd, 'NANSEN-addons'));
             try; run(fullfile('openMINDS_MATLAB','code','setup.m')); catch ME; ...
                 warning('openMINDS setup failed: %s', ME.message); end
             ndi.cloud.authenticate("InteractionEnabled", "off");

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -111,6 +111,21 @@ jobs:
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
 
+      - name: Install NANSEN dependencies
+        uses: matlab-actions/run-command@v2
+        with:
+          # NANSEN PR #103 dropped utility.dir.recursiveDir in favour
+          # of the FEX add-on (fex://160058), declared in NANSEN's
+          # requirements.txt. nansen_install would install it via
+          # matbox's AddonManager, but we skip nansen_install in CI
+          # for speed. Invoke installMissingAddons directly so the
+          # FEX-managed dependencies land on the path before tests.
+          command: |
+            addpath(genpath('NANSEN/code'));
+            am = nansen.config.addons.AddonManager.instance( ...
+                "AddonFolder", fullfile(pwd, 'NANSEN-addons'));
+            am.installMissingAddons();
+
       - name: Build mksqlite MEX
         uses: matlab-actions/run-command@v2
         with:
@@ -289,6 +304,16 @@ jobs:
       - name: Install MatBox
         if: steps.check_secrets.outputs.cloud_credentials_set == 'true'
         uses: ehennestad/matbox-actions/install-matbox@v1
+
+      - name: Install NANSEN dependencies
+        if: steps.check_secrets.outputs.cloud_credentials_set == 'true'
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            addpath(genpath('NANSEN/code'));
+            am = nansen.config.addons.AddonManager.instance( ...
+                "AddonFolder", fullfile(pwd, 'NANSEN-addons'));
+            am.installMissingAddons();
 
       - name: Build mksqlite MEX
         if: steps.check_secrets.outputs.cloud_credentials_set == 'true'


### PR DESCRIPTION
## Summary

NANSEN [PR #103](https://github.com/VervaekeLab/NANSEN/pull/103) (merged 2026-06-01) dropped the in-repo `utility.dir.recursiveDir` function in favor of the FEX add-on (`fex://160058`), declared in NANSEN's `requirements.txt`. Our CI clones NANSEN's `dev` branch and `addpaths` `code/` directly, but never resolves the requirements file, so `recursiveDir` is unresolved at test time.

Every test that goes through `ProjectManager.createProject` (the 28 tests in `MetatableMerge`, `MetatableEdit`, `MetatableRemove`, `FunHelpers`, `ValidateDuplicates`, `ValidateFileHasAllSubjects`, `ExportMetadata`) now errors with:

```
Undefined function 'recursiveDir' for input arguments of type 'char'.
Error in nansen.config.project.Project/updateModuleConfiguration (line 908)
Error in nansen.config.project.ProjectManager/createProject (line 157)
```

Both PR #45 (install path hardening) and PR #46 (validation noun fix) are blocked by this, even though their own changes don't touch any of the affected code paths.

## Fix

Add a new step in both the offline and cloud jobs that runs after MatBox is installed: `addpath` NANSEN's `code/`, grab the `AddonManager` singleton against a workspace-local `NANSEN-addons` folder, and call `installMissingAddons()` to pull every dependency declared in NANSEN's `requirements.txt` (recursiveDir, widgets-toolbox, etc.) before tests run.

`nansen_install` does the same thing client-side but at higher cost (interactive-friendly setup, savepath, etc.); the direct `installMissingAddons()` call is the minimal CI variant.

## Test plan

- [ ] Offline tests pass after this merges.
- [ ] Cloud tests pass when the cloud-credentials path is taken (e.g. on merges into main).
- [ ] PRs #45 and #46 rebase onto this and inherit green CI.
- [ ] Future NANSEN `requirements.txt` additions are picked up automatically — no further CI changes needed when NANSEN adds another FEX dependency.

## Followup

This is reactive. Pinning NANSEN to a stable ref (instead of `dev`) would prevent surprises like this entirely; punting that decision for now since the project's stated posture is to track NANSEN dev.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S7oxviMzuwcExHpW2J1eEs)_