### PR TITLE
Make sync.repo self-contained for the websave install bootstrap

### DIFF
--- a/src/ndi/+ndi/+nansen/+fun/cleanGenpath.m
+++ b/src/ndi/+ndi/+nansen/+fun/cleanGenpath.m
@@ -9,10 +9,13 @@ function pathStr = cleanGenpath(root)
 %   appears. Filter by path component so the saved pathdef.m stays
 %   stable across git GC and the in-memory path stays clean.
 %
-%   Note: install.m maintains its own copy of this logic as
-%   `install_genpathClean` because install.m must be self-contained
-%   (it is downloaded via websave and run before the rest of the
-%   codebase is on path). Keep the two implementations in lock-step.
+%   Note: two other copies of this logic exist because their callers
+%   must be self-contained — each is downloaded via websave and runs
+%   before the rest of the codebase is on path:
+%     * `install_genpathClean` in install.m
+%     * `repo_cleanGenpath` in ndi.nansen.sync.repo (bootstrapped on
+%       its own to clone nansen-pulakat itself)
+%   Keep all three implementations in lock-step.
 %
 %   Inputs:
 %      root (char or string): The folder to recursively expand.

--- a/src/ndi/+ndi/+nansen/+sync/repo.m
+++ b/src/ndi/+ndi/+nansen/+sync/repo.m
@@ -194,13 +194,22 @@ end
 % --- 5. Path Management & Reporting ---
 
 if status == 0
-    % Ensure the updated code is on the MATLAB path. Use cleanGenpath
-    % so .git/objects/<hash>, .github, and node_modules don't pollute
-    % the in-memory path (and the savepath() below); install.m uses
-    % the same filter at install time.
+    % Ensure the updated code is on the MATLAB path. Use the local
+    % repo_cleanGenpath so .git/objects/<hash>, .github, and
+    % node_modules don't pollute the in-memory path (and the savepath()
+    % below); install.m uses the same filter at install time.
+    %
+    % This MUST be a self-contained local copy rather than a call to
+    % ndi.nansen.fun.cleanGenpath: install.m bootstraps this file
+    % alone via websave and runs it to clone nansen-pulakat itself, so
+    % on that first call the +ndi/+nansen/+fun package is not yet on
+    % the path — this addpath line is what would put it there. Calling
+    % the package function would fail with "Unable to resolve the name
+    % 'ndi.nansen.fun.cleanGenpath'". Keep this in lock-step with
+    % ndi.nansen.fun.cleanGenpath and install.m's install_genpathClean.
     fprintf('[%s] Updating MATLAB path for %s\n', infoTag, repoName);
     pathBefore = path;
-    addpath(ndi.nansen.fun.cleanGenpath(repoPath));
+    addpath(repo_cleanGenpath(repoPath));
 
     % Save to a user-writable location so savepath does not fail on
     % MATLAB installs where matlabroot is read-only. Skip the write if
@@ -226,4 +235,30 @@ else
         '[%s:PullFailed] Update failed for %s:\n%s', funcId, repoName, pullOut);
 end
 
+end
+
+function pathStr = repo_cleanGenpath(root)
+% genpath(root) with .git, .github, and node_modules filtered out.
+%
+% Self-contained local copy of ndi.nansen.fun.cleanGenpath (and the
+% equivalent install_genpathClean in install.m). repo.m is bootstrapped
+% on its own via websave during a fresh install and runs before the rest
+% of the codebase is on the path, so it cannot depend on the +fun
+% package being resolvable. Keep all three implementations in lock-step.
+parts = strsplit(genpath(char(root)), pathsep);
+parts = parts(~cellfun('isempty', parts));
+excluded = {'.git', '.github', 'node_modules'};
+keep = true(1, numel(parts));
+for i = 1:numel(parts)
+    p = parts{i};
+    for j = 1:numel(excluded)
+        token = excluded{j};
+        if endsWith(p, [filesep, token]) || ...
+                contains(p, [filesep, token, filesep])
+            keep(i) = false;
+            break
+        end
+    end
+end
+pathStr = strjoin(parts(keep), pathsep);
 end

--- a/tests/+ndi/+unittest/+nansen/SyncRepo.m
+++ b/tests/+ndi/+unittest/+nansen/SyncRepo.m
@@ -65,6 +65,26 @@ classdef SyncRepo < matlab.unittest.TestCase
             end
         end
 
+        function testRepoIsSelfContained(testCase)
+            % Regression test for the bootstrap install failure
+            % "Unable to resolve the name 'ndi.nansen.fun.cleanGenpath'".
+            %
+            % install.m downloads repo.m alone via websave and runs it to
+            % clone nansen-pulakat itself. On that first call the rest of
+            % the codebase (including the +ndi/+nansen/+fun package) is not
+            % yet on the path, so repo.m must not call into it. Assert the
+            % source does not reference any ndi.nansen.fun.* helper; it
+            % carries its own repo_cleanGenpath local copy instead.
+            repoSource = which('ndi.nansen.sync.repo');
+            testCase.assertNotEmpty(repoSource, ...
+                'Could not locate ndi.nansen.sync.repo on the path.');
+            src = fileread(repoSource);
+            testCase.verifyFalse(contains(src, 'ndi.nansen.fun.'), ...
+                ['repo.m must be self-contained for the websave bootstrap; ' ...
+                 'it must not call ndi.nansen.fun.* (use the local ' ...
+                 'repo_cleanGenpath instead).']);
+        end
+
         function testPathdefWrittenToUserpath(testCase)
             % Verify that a successful sync writes pathdef.m to userpath
             % so paths persist across MATLAB sessions. Preserve any

--- a/tests/+ndi/+unittest/+nansen/SyncRepo.m
+++ b/tests/+ndi/+unittest/+nansen/SyncRepo.m
@@ -75,11 +75,24 @@ classdef SyncRepo < matlab.unittest.TestCase
             % yet on the path, so repo.m must not call into it. Assert the
             % source does not reference any ndi.nansen.fun.* helper; it
             % carries its own repo_cleanGenpath local copy instead.
+            %
+            % Comments are stripped before the check: repo.m's own
+            % documentation deliberately names ndi.nansen.fun.cleanGenpath
+            % to explain why the local copy exists, and a raw substring
+            % scan would flag that prose. Only executable code should be
+            % searched for a real call.
             repoSource = which('ndi.nansen.sync.repo');
             testCase.assertNotEmpty(repoSource, ...
                 'Could not locate ndi.nansen.sync.repo on the path.');
-            src = fileread(repoSource);
-            testCase.verifyFalse(contains(src, 'ndi.nansen.fun.'), ...
+            lines = splitlines(string(fileread(repoSource)));
+            for i = 1:numel(lines)
+                pct = strfind(lines(i), '%');
+                if ~isempty(pct)
+                    lines(i) = extractBefore(lines(i), pct(1));
+                end
+            end
+            codeBody = strjoin(lines, newline);
+            testCase.verifyFalse(contains(codeBody, 'ndi.nansen.fun.'), ...
                 ['repo.m must be self-contained for the websave bootstrap; ' ...
                  'it must not call ndi.nansen.fun.* (use the local ' ...
                  'repo_cleanGenpath instead).']);


### PR DESCRIPTION
## Problem

A fresh install fails immediately after cloning nansen-pulakat:

```
[NDI Sync] Updating MATLAB path for nansen-pulakat
Unable to resolve the name 'ndi.nansen.fun.cleanGenpath'.
Error in repo (line 203)
    addpath(ndi.nansen.fun.cleanGenpath(repoPath));
Error in install (line 107)
status = repoSync(pulakatURL,'ClonePath',codePath,'Branch','main');
```

## Root cause

`install.m` (step 3) bootstraps a fresh machine by downloading **only** `repo.m`
via `websave` and adding the temp folder to the path. When `repoSync` then runs
for the very first repo — nansen-pulakat itself (`install.m:107`) — it clones the
repo and reaches `repo.m:203`:

```matlab
addpath(ndi.nansen.fun.cleanGenpath(repoPath));
```

But `ndi.nansen.fun.cleanGenpath` lives *inside* nansen-pulakat, which is not on
the path yet — that very `addpath` is what would put it there. Chicken-and-egg.

`install.m` already anticipates this exact constraint: it keeps its own
self-contained copy, `install_genpathClean`, *because* it "is downloaded via
websave and run before the rest of the codebase is on path." `repo.m` is
bootstrapped the same way but was left depending on the package function.

CI never caught it because the test suite runs with the whole repo already on
the path, so the package function always resolved.

## Fix

- Replace the `ndi.nansen.fun.cleanGenpath` call in `repo.m` with a
  self-contained local subfunction `repo_cleanGenpath`, mirroring
  `install_genpathClean` in `install.m`.
- Document the three copies (now `cleanGenpath`, `install_genpathClean`,
  `repo_cleanGenpath`) as a lock-step set.
- Add `SyncRepo.testRepoIsSelfContained` — a regression test asserting `repo.m`
  does not reference any `ndi.nansen.fun.*` helper.

https://claude.ai/code/session_01WBSzgbsQQC18n23HEauPDM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBSzgbsQQC18n23HEauPDM)_