### PR TITLE
Fix File Validate crash on valid files; clearer error for incompatible session import

### DIFF
--- a/src/ndi/+ndi/+nansen/+import/session.m
+++ b/src/ndi/+ndi/+nansen/+import/session.m
@@ -37,8 +37,30 @@ sessionName = cellstr(sessionName); sessionName = sessionName{1};
 % Create session
 session = ndi.session.dir(sessionName, sessionPath);
 
-% Add session to dataset
-dataset.add_ingested_session(session);
+% Add session to dataset. add_ingested_session copies every document in
+% the session into the dataset's database, where each is re-validated
+% against its NDI/DID schema. An incompatible or incomplete session is
+% correctly rejected there — but the raw failure is a deep DID:Database
+% assertion that gives the user no idea what went wrong or what to do.
+% Catch that family and re-throw a plain-language error naming the
+% likely cause; let anything else propagate unchanged.
+funcId = 'NDI:Nansen:Import:Session';
+try
+    dataset.add_ingested_session(session);
+catch ME
+    if startsWith(ME.identifier, 'DID:')
+        error([funcId, ':IncompatibleSession'], ...
+            ['[%s:IncompatibleSession] The session at "%s" could not be ' ...
+             'imported: one of its documents failed database validation. ' ...
+             'This usually means the folder is not a complete or ' ...
+             'compatible NDI session — check that you selected the right ' ...
+             'session folder and that it was created with a compatible ' ...
+             'version.\nUnderlying error (%s): %s'], ...
+            funcId, sessionPath, ME.identifier, ME.message);
+    else
+        rethrow(ME);
+    end
+end
 
 end
 

--- a/src/pulakat/code/+pulakat/+objectmethod/+file/+methods/validate.m
+++ b/src/pulakat/code/+pulakat/+objectmethod/+file/+methods/validate.m
@@ -32,9 +32,17 @@ function varargout = validate(fileObject, varargin)
 
     % --- Implementation of the method ---
 
-    project = nansen.getCurrentProject;
-    metaTable = project.MetaTableCatalog.getMetaTable('File');
-    fileTable = metaTable.getEntry({fileObject.FileIdentifier});
+    % Build the table straight from the selected row struct. The struct
+    % already carries every column the validator and the IsDocumented
+    % check need (SessionName, ElectronicFileName, DataTypeName,
+    % SubjectDocumentIdentifier, SessionIdentifier, SubjectIdentifier and
+    % FileDocumentIdentifier). Re-fetching with
+    % metaTable.getEntry({fileObject.FileIdentifier}) is both unnecessary
+    % and fragile: the File row struct handed to the object method does
+    % not reliably carry a FileIdentifier field, so keying off it threw
+    % "Unrecognized field name FileIdentifier" before validation could
+    % run.
+    fileTable = struct2table(fileObject, 'AsArray', true);
 
     [isValid, reportTable] = ndi.nansen.import.file.validate(fileTable);
     isDocument = ~strcmp(fileTable.FileDocumentIdentifier, 'N/A');


### PR DESCRIPTION
Two focused changes, after walking back an earlier speculative approach.

## 1. File Validate crashed on correct files (real bug)

`pulakat.objectmethod.file.methods.validate` re-fetched rows with
`metaTable.getEntry({fileObject.FileIdentifier})`, but the File row struct NANSEN
hands the method doesn't reliably carry a `FileIdentifier` field — so validating
perfectly valid files threw `Unrecognized field name "FileIdentifier"` before any
checking happened.

**Fix:** build the report table directly from the selected row struct
(`struct2table`), as the method did before a recent validation-report refactor.
It validates exactly the rows you selected and carries every column the validator
needs, so correct files validate without crashing.

## 2. Importing an incompatible session gave an opaque error

Importing a session that isn't a complete/compatible NDI session *correctly* fails —
`add_ingested_session` copies the folder's documents into the dataset and the
database rejects an invalid one. But the failure surfaced as a deep
`DID:Database:ValidationDependsOn` assertion with no indication of cause.

**Fix:** wrap the ingest in `ndi.nansen.import.session` and translate any `DID:`
database-validation failure into a plain-language
`NDI:Nansen:Import:Session:IncompatibleSession` error that names the folder and the
likely cause (wrong folder / incomplete / incompatible version), while still
embedding the underlying error. Non-`DID:` errors propagate unchanged. The import
still fails — as it should — just legibly.

## What was removed (and why)

An earlier revision of this branch added two changes that I walked back after the
real workflow became clear:

- A row-skip guard in `ndi.nansen.import.subject.documents` — it silently dropped
  subject rows that failed to document (hiding data loss), addressed a condition
  that was never reproduced, and lived in the Document path, which import never runs.
- A `syncColumns` startup reconcile (helper + startup call + test + CI entry) —
  unverified insurance for the File Document/Export path (not exercised here), partly
  redundant with `updateAll`, and it backfilled the identity column with placeholder
  values in a way that wasn't proven safe.

## Caveats
- Not run locally — no MATLAB / NANSEN checkout in this environment. The Validate fix
  restores a previously-shipped approach; the import error wrapper only adds a
  try/catch + message and changes no success-path behavior.
- The `datalocation_settings.mat` commit on this branch came from the project side,
  not from these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)